### PR TITLE
Unprofile UX improvements

### DIFF
--- a/packages/common/src/components/Alert.jsx
+++ b/packages/common/src/components/Alert.jsx
@@ -11,28 +11,28 @@ import React from 'react'
 const alertStylesByType = {
   default: {
     backgroundColor: 'bg-yellow-100',
-    textColor: 'text-gray-600',
+    textColor: 'text-gray-600'
   },
   success: {
     backgroundColor: 'bg-green-200',
-    textColor: 'text-gray-600',
+    textColor: 'text-gray-600'
   },
   danger: {
     backgroundColor: 'bg-red-200',
-    textColor: 'text-gray-600',
+    textColor: 'text-gray-600'
   },
   transparent: {
     backgroundColor: '',
-    textColor: 'text-gray-600',
+    textColor: 'text-gray-600'
   }
 }
 
 export default function Alert (props) {
-  const { type, children } = props;
+  const { type, children } = props
   const alertStyles = alertStylesByType[type] || alertStylesByType.default
   const backgroundColor = props.backgroundColor || alertStyles.backgroundColor
   const textColor = props.textColor || alertStyles.textColor
-  
+
   return (
     <div className={`my-4 px-4 py-4 ${backgroundColor} ${textColor} rounded`}>
       {children}

--- a/packages/common/src/components/Alert.jsx
+++ b/packages/common/src/components/Alert.jsx
@@ -8,7 +8,7 @@
 
 import React from 'react'
 
-const alertStylesByType = {
+const styles = {
   default: {
     backgroundColor: 'bg-yellow-100',
     textColor: 'text-gray-600'
@@ -27,14 +27,12 @@ const alertStylesByType = {
   }
 }
 
-export default function Alert (props) {
-  const { type, children } = props
-  const alertStyles = alertStylesByType[type] || alertStylesByType.default
-  const backgroundColor = props.backgroundColor || alertStyles.backgroundColor
-  const textColor = props.textColor || alertStyles.textColor
+export default ({ children, backgroundColor, textColor, type = 'default' }) => {
+  const backgroundColorStyle = backgroundColor || styles[type].backgroundColor
+  const textColorStyle = textColor || styles[type].textColor
 
   return (
-    <div className={`my-4 px-4 py-4 ${backgroundColor} ${textColor} rounded`}>
+    <div className={`my-4 px-4 py-4 ${backgroundColorStyle} ${textColorStyle} rounded`}>
       {children}
     </div>
   )

--- a/packages/common/src/components/Alert.jsx
+++ b/packages/common/src/components/Alert.jsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Kernel
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React from 'react'
+
+const alertStylesByType = {
+  default: {
+    backgroundColor: 'bg-yellow-100',
+    textColor: 'text-gray-600',
+  },
+  success: {
+    backgroundColor: 'bg-green-200',
+    textColor: 'text-gray-600',
+  },
+  danger: {
+    backgroundColor: 'bg-red-200',
+    textColor: 'text-gray-600',
+  },
+  transparent: {
+    backgroundColor: '',
+    textColor: 'text-gray-600',
+  }
+}
+
+export default function Alert (props) {
+  const { type, children } = props;
+  const alertStyles = alertStylesByType[type] || alertStylesByType.default
+  const backgroundColor = props.backgroundColor || alertStyles.backgroundColor
+  const textColor = props.textColor || alertStyles.textColor
+  
+  return (
+    <div className={`my-4 px-4 py-4 ${backgroundColor} ${textColor} rounded`}>
+      {children}
+    </div>
+  )
+}

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -17,9 +17,10 @@ import { ServicesProvider, useServices } from './contexts/ServicesContext.js'
 import Footer from './components/Footer'
 import Navbar from './components/Navbar'
 import NavbarLink from './components/NavbarLink'
+import Alert from './components/Alert'
 
 export {
   jwtService, rpcClient,
   ServicesProvider, useServices,
-  Footer, Navbar, NavbarLink
+  Footer, Navbar, NavbarLink, Alert
 }

--- a/packages/profile/package.json
+++ b/packages/profile/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@craco/craco": "^6.4.3",
     "@fortawesome/fontawesome-free": "^6.1.0",
+    "@headlessui/react": "^1.6.1",
     "@kernel/common": "^0.0.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -8,6 +8,7 @@
 
 import { useEffect, useReducer, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { Switch } from '@headlessui/react'
 import { useServices, Navbar, Footer, Alert } from '@kernel/common'
 
 import AppConfig from 'App.config'
@@ -80,6 +81,8 @@ const Profile = () => {
   const { services, currentUser } = useServices()
   const user = currentUser()
 
+  const [consentToggleEnabled, setConsentToggleEnabled] = useState(value(state, 'consent'))
+
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState(null)
   const [errorMessage, setErrorMessage] = useState(null)
@@ -118,6 +121,16 @@ const Profile = () => {
       }
     })()
   }, [services, user])
+
+  const changeConsentToggle = (enabled) => {
+    setConsentToggleEnabled(enabled)
+
+    try {
+      dispatch({ type: 'consent', payload: enabled })
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
   const save = async (state, dispatch, e) => {
     e.preventDefault()
@@ -186,13 +199,22 @@ const Profile = () => {
             )
           })}
           <div className='mt-8 mb-2'>
-            <label className='label'>
-              <input
-                type='checkbox' className='checkbox checkbox-primary cursor-pointer align-middle'
-                checked={value(state, 'consent')} onChange={change.bind(null, dispatch, 'consent')}
-              />
-              <span className='label-text ml-1.5 align-middle'>Make my information available to others</span>
-            </label>
+            <Switch.Group>
+              <Switch
+                checked={consentToggleEnabled}
+                onChange={changeConsentToggle}
+                className={`${
+                  consentToggleEnabled ? 'bg-kernel-green-dark' : 'bg-gray-200'
+                } relative inline-flex h-6 w-9 items-center rounded-full`}
+              >
+                <span
+                  className={`transform transition ease-in-out duration-200 ${
+                    consentToggleEnabled ? 'translate-x-4' : 'translate-x-1'
+                  } inline-block h-4 w-4 transform rounded-full bg-white`}
+                />
+              </Switch>
+              <Switch.Label passive className='ml-2 align-top'>Make my information available to others</Switch.Label>
+            </Switch.Group>
           </div>
           <button
             disabled={submitting}

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -169,7 +169,7 @@ const Profile = () => {
     }
   }
 
-  let alert;
+  let alert
   if (submitting) {
     alert = <Alert type='transparent'>Saving your changes...</Alert>
   } else if (result) {

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -25,10 +25,10 @@ INITIAL_FORM_FIELDS_STATE.consent = true
 const INITIAL_FORM_SUBMISSION_STATE = {
   formStatus: 'clean',
   errorMessage: null,
-  consentToggleEnabled: INITIAL_FORM_FIELDS_STATE.consent,
+  consentToggleEnabled: INITIAL_FORM_FIELDS_STATE.consent
 }
 
-const INITIAL_STATE = {...INITIAL_FORM_FIELDS_STATE, ...INITIAL_FORM_SUBMISSION_STATE}
+const INITIAL_STATE = { ...INITIAL_FORM_FIELDS_STATE, ...INITIAL_FORM_SUBMISSION_STATE }
 
 const actions = {}
 
@@ -74,7 +74,7 @@ const save = async (state, dispatch, e) => {
     'profiles',
     'members',
     'profileId',
-    'wallet',
+    'wallet'
   ].concat(Object.keys(INITIAL_FORM_SUBMISSION_STATE))
 
   const { profiles, members, memberId, profileId } = state

--- a/packages/profile/src/views/Profile.jsx
+++ b/packages/profile/src/views/Profile.jsx
@@ -6,7 +6,7 @@
  *
  */
 
-import { useEffect, useReducer, useState } from 'react'
+import { useEffect, useReducer } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Switch } from '@headlessui/react'
 import { useServices, Navbar, Footer, Alert } from '@kernel/common'
@@ -17,17 +17,25 @@ const FORM_INPUT = ['email', 'name', 'pronouns', 'twitter', 'city', 'company', '
 
 // initializes state in the form:
 // { wallet: '', email: '', consent: true }
-const INITIAL_STATE_KEYS = ['wallet'].concat(FORM_INPUT)
-const INITIAL_STATE = INITIAL_STATE_KEYS
+const INITIAL_FORM_KEYS = ['wallet'].concat(FORM_INPUT)
+const INITIAL_FORM_FIELDS_STATE = INITIAL_FORM_KEYS
   .reduce((acc, key) => Object.assign(acc, { [key]: '' }), {})
-INITIAL_STATE.consent = true
+INITIAL_FORM_FIELDS_STATE.consent = true
+
+const INITIAL_FORM_SUBMISSION_STATE = {
+  formStatus: 'clean',
+  errorMessage: null,
+  consentToggleEnabled: INITIAL_FORM_FIELDS_STATE.consent,
+}
+
+const INITIAL_STATE = {...INITIAL_FORM_FIELDS_STATE, ...INITIAL_FORM_SUBMISSION_STATE}
 
 const actions = {}
 
 // initializes an actions object in the form:
 // { bio: (state, value) => Object.assign({}, state, bio: value}) }
 // each field's action updates the state with the given value
-INITIAL_STATE_KEYS
+Object.keys(INITIAL_STATE)
   .concat(['consent', 'profiles', 'members', 'memberId', 'profileId'])
   .forEach((key) => {
     actions[key] = (state, value) => Object.assign({}, state, { [key]: value })
@@ -57,6 +65,46 @@ const change = (dispatch, type, e) => {
 
 const value = (state, type) => state[type]
 
+const save = async (state, dispatch, e) => {
+  e.preventDefault()
+  dispatch({ type: 'formStatus', payload: 'submitting' })
+  dispatch({ type: 'errorMessage', payload: null })
+
+  const keysToExclude = [
+    'profiles',
+    'members',
+    'profileId',
+    'wallet',
+  ].concat(Object.keys(INITIAL_FORM_SUBMISSION_STATE))
+
+  const { profiles, members, memberId, profileId } = state
+  const data = Object.keys(state)
+    .filter(key => !keysToExclude.includes(key))
+    .reduce((acc, key) => Object.assign(acc, { [key]: state[key] }), {})
+  console.log(data)
+
+  try {
+    if (profileId && memberId) {
+      const patched = await profiles.patch(profileId, data)
+      console.log('patched', patched)
+      dispatch({ type: 'formStatus', payload: 'success' })
+      return patched
+    }
+
+    const profile = await profiles.create(data)
+    console.log('new', profile)
+    dispatch({ type: 'profileId', payload: profile.id })
+
+    const member = await members.patch(profile.data.memberId, { profileId: profile.id })
+    console.log(member)
+    dispatch({ type: 'formStatus', payload: 'success' })
+    // dispatch({ type: 'created', payload: updated })
+  } catch (error) {
+    dispatch({ type: 'formStatus', payload: 'error' })
+    dispatch({ type: 'errorMessage', payload: error.message })
+  }
+}
+
 const Input = ({ fieldName, editable = true, state, dispatch }) => {
   const disabled = !editable
   const bgColorClass = disabled ? 'bg-gray-200' : ''
@@ -74,18 +122,25 @@ const Input = ({ fieldName, editable = true, state, dispatch }) => {
   )
 }
 
+const ProfileAlert = ({ formStatus, errorMessage }) => {
+  switch (formStatus) {
+    case 'submitting':
+      return <Alert type='transparent'>Saving your changes...</Alert>
+    case 'success':
+      return <Alert type='success'>Your changes have been saved!</Alert>
+    case 'error':
+      return <Alert type='danger'>Something went wrong. {errorMessage}</Alert>
+    default:
+      return <Alert type='transparent' />
+  }
+}
+
 const Profile = () => {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE)
   const navigate = useNavigate()
 
   const { services, currentUser } = useServices()
   const user = currentUser()
-
-  const [consentToggleEnabled, setConsentToggleEnabled] = useState(value(state, 'consent'))
-
-  const [submitting, setSubmitting] = useState(false)
-  const [result, setResult] = useState(null)
-  const [errorMessage, setErrorMessage] = useState(null)
 
   useEffect(() => {
     if (!user || user.role > AppConfig.minRole) {
@@ -123,63 +178,13 @@ const Profile = () => {
   }, [services, user])
 
   const changeConsentToggle = (enabled) => {
-    setConsentToggleEnabled(enabled)
+    dispatch({ type: 'consentToggleEnabled', payload: enabled })
 
     try {
       dispatch({ type: 'consent', payload: enabled })
     } catch (error) {
       console.log(error)
     }
-  }
-
-  const save = async (state, dispatch, e) => {
-    e.preventDefault()
-    setSubmitting(true)
-    setResult(null)
-    setErrorMessage(null)
-
-    const { profiles, members, memberId, profileId } = state
-    const data = Object.keys(state)
-      .filter(key => !['profiles', 'members', 'profileId', 'wallet'].includes(key))
-      .reduce((acc, key) => Object.assign(acc, { [key]: state[key] }), {})
-    console.log(data)
-
-    try {
-      if (profileId && memberId) {
-        const patched = await profiles.patch(profileId, data)
-        console.log('patched', patched)
-        setSubmitting(false)
-        setResult('success')
-        return patched
-      }
-
-      const profile = await profiles.create(data)
-      console.log('new', profile)
-      dispatch({ type: 'profileId', payload: profile.id })
-
-      const member = await members.patch(profile.data.memberId, { profileId: profile.id })
-      console.log(member)
-      setSubmitting(false)
-      setResult('success')
-      // dispatch({ type: 'created', payload: updated })
-    } catch (error) {
-      setSubmitting(false)
-      setResult('error')
-      setErrorMessage(error.message)
-    }
-  }
-
-  let alert
-  if (submitting) {
-    alert = <Alert type='transparent'>Saving your changes...</Alert>
-  } else if (result) {
-    if (result === 'success') {
-      alert = <Alert type='success'>Your changes have been saved!</Alert>
-    } else if (result === 'error') {
-      alert = <Alert type='danger'>Something went wrong. {errorMessage}</Alert>
-    }
-  } else {
-    alert = <Alert type='transparent' />
   }
 
   return (
@@ -201,15 +206,15 @@ const Profile = () => {
           <div className='mt-8 mb-2'>
             <Switch.Group>
               <Switch
-                checked={consentToggleEnabled}
+                checked={state.consentToggleEnabled}
                 onChange={changeConsentToggle}
                 className={`${
-                  consentToggleEnabled ? 'bg-kernel-green-dark' : 'bg-gray-200'
+                  state.consentToggleEnabled ? 'bg-kernel-green-dark' : 'bg-gray-200'
                 } relative inline-flex h-6 w-9 items-center rounded-full`}
               >
                 <span
                   className={`transform transition ease-in-out duration-200 ${
-                    consentToggleEnabled ? 'translate-x-4' : 'translate-x-1'
+                    state.consentToggleEnabled ? 'translate-x-4' : 'translate-x-1'
                   } inline-block h-4 w-4 transform rounded-full bg-white`}
                 />
               </Switch>
@@ -217,14 +222,14 @@ const Profile = () => {
             </Switch.Group>
           </div>
           <button
-            disabled={submitting}
+            disabled={state.formStatus === 'submitting'}
             onClick={save.bind(null, state, dispatch)}
-            className={`mt-6 mb-4 px-6 py-4 ${submitting ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
+            className={`mt-6 mb-4 px-6 py-4 ${state.formStatus === 'submitting' ? 'bg-gray-300' : 'bg-kernel-green-dark'} text-kernel-white w-full rounded font-bold`}
           >
             Save
           </button>
 
-          {alert}
+          <ProfileAlert formStatus={state.formStatus} errorMessage={state.errorMessage} />
 
         </form>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,6 +1623,11 @@
     protobufjs "^6.10.0"
     yargs "^16.2.0"
 
+"@headlessui/react@^1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.1.tgz#d822792e589aac005462491dd62f86095e0c3bef"
+  integrity sha512-gMd6uIs1U4Oz718Z5gFoV0o/vD43/4zvbyiJN9Dt7PK9Ubxn+TmJwTmYwyNJc5KxxU1t0CmgTNgwZX9+4NjCnQ==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
@@ -6566,31 +6571,12 @@ gaxios@^4.0.0:
     is-stream "^2.0.0"
     node-fetch "^2.6.7"
 
-gaxios@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-5.0.0.tgz#df11e5d0a45831dd39eb5fbbba0d6a6b09815e70"
-  integrity sha512-VD/yc5ln6XU8Ch1hyYY6kRMBE0Yc2np3fPyeJeYHhrPs1i8rgnsApPMWyrugkl7LLoSqpOJVBWlQIa87OAvt8Q==
-  dependencies:
-    abort-controller "^3.0.0"
-    extend "^3.0.2"
-    https-proxy-agent "^5.0.0"
-    is-stream "^2.0.0"
-    node-fetch "^2.6.7"
-
 gcp-metadata@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.3.1.tgz#fb205fe6a90fef2fd9c85e6ba06e5559ee1eefa9"
   integrity sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==
   dependencies:
     gaxios "^4.0.0"
-    json-bigint "^1.0.0"
-
-gcp-metadata@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-5.0.0.tgz#a00f999f60a4461401e7c515f8a3267cfb401ee7"
-  integrity sha512-gfwuX3yA3nNsHSWUL4KG90UulNiq922Ukj3wLTrcnX33BB7PwB1o0ubR8KVvXu9nJH+P5w1j2SQSNNqto+H0DA==
-  dependencies:
-    gaxios "^5.0.0"
     json-bigint "^1.0.0"
 
 gensync@^1.0.0-beta.2:
@@ -6739,21 +6725,6 @@ google-auth-library@^7.0.2, google-auth-library@^7.14.0, google-auth-library@^7.
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-auth-library@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-8.0.2.tgz#5fa0f2d3795c3e4019d2bb315ade4454cc9c30b5"
-  integrity sha512-HoG+nWFAThLovKpvcbYzxgn+nBJPTfAwtq0GxPN821nOO+21+8oP7MoEHfd1sbDulUFFGfcjJr2CnJ4YssHcyg==
-  dependencies:
-    arrify "^2.0.0"
-    base64-js "^1.3.0"
-    ecdsa-sig-formatter "^1.0.11"
-    fast-text-encoding "^1.0.0"
-    gaxios "^5.0.0"
-    gcp-metadata "^5.0.0"
-    gtoken "^5.3.2"
-    jws "^4.0.0"
-    lru-cache "^6.0.0"
-
 google-gax@^2.24.1, google-gax@^2.30.0:
   version "2.30.2"
   resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.30.2.tgz#ba16940bad5a116099547a5966fdf83f6c026356"
@@ -6805,7 +6776,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-gtoken@^5.0.4, gtoken@^5.3.2:
+gtoken@^5.0.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.3.2.tgz#deb7dc876abe002178e0515e383382ea9446d58f"
   integrity sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==


### PR DESCRIPTION
Addresses #9 and #22 

+ Adds common Alert component with a few variants
+ Adds success/error alert to Unprofile submission
+ Adds HeadlessUI to Unprofile project and replaces the consent checkbox with its Switch (toggle) component

Caveats:
In `Profile.jsx`, I moved the `save` function inside of the `Profile` component, because it needs access to a bunch of `useState` values which have to be defined in the component.

Examples of different alerts:
![Screen Shot 2022-05-13 at 6 03 51 PM](https://user-images.githubusercontent.com/4686089/168400866-6265061c-2ecc-41a8-84f4-7c8aa447e896.png)

Feedback on Unprofile submission:
![Screen Shot 2022-05-13 at 7 09 08 PM](https://user-images.githubusercontent.com/4686089/168400867-7a6fc3d6-05c0-46b2-bc1c-fa17fe51d9a0.png)
